### PR TITLE
Implement rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module gowarp
 
 go 1.18
+
+require golang.org/x/time v0.0.0-20220411224347-583f2d630306

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/time v0.0.0-20220411224347-583f2d630306 h1:+gHMid33q6pen7kv9xvT+JRinntgeXO2AeZVd0AWD3w=
+golang.org/x/time v0.0.0-20220411224347-583f2d630306/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/main.go
+++ b/main.go
@@ -6,7 +6,57 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sync"
+
+	"golang.org/x/time/rate"
 )
+
+type IPRateLimiter struct {
+	ips   map[string]*rate.Limiter
+	mutex *sync.RWMutex
+	rate  rate.Limit
+	size  int
+}
+
+func NewIPRateLimiter(r rate.Limit, b int) *IPRateLimiter {
+	i := &IPRateLimiter{
+		ips:   make(map[string]*rate.Limiter),
+		mutex: &sync.RWMutex{},
+		rate:  r,
+		size:  b,
+	}
+
+	return i
+}
+
+// AddIP creates a new rate limiter and adds it to the ips map,
+// using the IP address as the key
+func (i *IPRateLimiter) AddIP(ip string) *rate.Limiter {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	limiter := rate.NewLimiter(i.rate, i.size)
+
+	i.ips[ip] = limiter
+
+	return limiter
+}
+
+// GetLimiter returns the rate limiter for the provided IP address if it exists.
+// Otherwise calls AddIP to add IP address to the map
+func (i *IPRateLimiter) GetLimiter(ip string) *rate.Limiter {
+	i.mutex.Lock()
+	limiter, exists := i.ips[ip]
+
+	if !exists {
+		i.mutex.Unlock()
+		return i.AddIP(ip)
+	}
+
+	i.mutex.Unlock()
+
+	return limiter
+}
 
 // warp is an http.HandleFunc that generates a warp+ key and writes it to the http.ResponseWriter
 func warp(w http.ResponseWriter, r *http.Request) {
@@ -26,8 +76,27 @@ func configUpdate(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Updated config!\n")
 }
 
+var limiter = NewIPRateLimiter(1, 2)
+
 func main() {
-	http.HandleFunc("/", warp)
-	http.HandleFunc("/config/update", configUpdate)
-	log.Fatal(http.ListenAndServe(":"+os.Getenv("PORT"), nil))
+	mux := http.NewServeMux()
+
+	warpHandler := http.HandlerFunc(warp)
+	configHandler := http.HandlerFunc(configUpdate)
+
+	mux.Handle("/", limitMiddleware(warpHandler))
+	mux.Handle("/config/update", limitMiddleware(configHandler))
+
+	log.Fatal(http.ListenAndServe(":"+os.Getenv("PORT"), mux))
+}
+
+func limitMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		limiter := limiter.GetLimiter(r.RemoteAddr)
+		if !limiter.Allow() {
+			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
With rate limiting, users can no longer spam reload to get all the keys at once or otherwise make the experience bad for the other users.